### PR TITLE
retain temp_target if exists

### DIFF
--- a/manifests/jdk.pp
+++ b/manifests/jdk.pp
@@ -96,7 +96,8 @@ define windows_java::jdk(
       $jreInstallPath = $jre_install_path
     }
     file{ $temp_target:
-      ensure => directory,
+      ensure  => directory,
+      replace => no,
     }
 
     $filename = filename($remoteSource)


### PR DESCRIPTION
in some environments, this can already exist as a link, and making it a
directory destroys the link (e.g. a shared folder under Vagrant)